### PR TITLE
feat: introduce a normalize flag to be able to skip the current folder/header normalize step

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ php artisan vendor:publish --provider="Lukasss93\Larex\LarexServiceProvider" --t
 * You can use `php artisan larex:insert` to add new items via CLI too!
 * You can use `php artisan larex:import --include=en,it` to import only _"en"_ and _"it"_ items.
 * You can use `php artisan larex:import --exclude=it` to import all items except _"it"_ item.
+* You can use `php artisan larex:import --normalize-folder-name=false` to keep the same csv header name as the folder name. (defaults to true)
 * You can use `php artisan larex:export --include=en,it` to export only _"en"_ and _"it"_ columns.
 * You can use `php artisan larex:export --exclude=it` to export all columns except _"it"_ column.
+* You can use `php artisan larex:export --normalize-folder-name=false` to keep the same folder name as the csv header name. (defaults to true)
 * You can use `php artisan larex:localize` to find unlocalized strings (use the `--import` option to add strings in your
   CSV).
 * You can use `php artisan larex:find` to search existing groups or keys in your CSV file.

--- a/src/Console/LarexExportCommand.php
+++ b/src/Console/LarexExportCommand.php
@@ -19,7 +19,8 @@ class LarexExportCommand extends Command
                             {exporter? : Exporter}
                             {--watch : Watch the CSV file from changes}
                             {--include= : Languages allowed to export in the application}
-                            {--exclude= : Languages not allowed to export in the application}';
+                            {--exclude= : Languages not allowed to export in the application}
+                            {--normalize-folder-name=true : Normalize the folder name from csv header or keep as is without transforms}';
 
     /**
      * The console command description.

--- a/src/Console/LarexImportCommand.php
+++ b/src/Console/LarexImportCommand.php
@@ -23,7 +23,8 @@ class LarexImportCommand extends Command
                             {--f|force : Overwrite CSV file if already exists}
                             {--include= : Languages allowed to import in the CSV}
                             {--exclude= : Languages not allowed to import in the CSV}
-                            {--skip-source-reordering : Skip source reordering}';
+                            {--skip-source-reordering : Skip source reordering}
+                            {--normalize-folder-name=true : Normalize the folder name from csv header or keep as is without transforms}';
 
     /**
      * The console command description.
@@ -113,8 +114,10 @@ class LarexImportCommand extends Command
 
         //set source languages
         if (!$this->option('skip-source-reordering')) {
-            $this->callSilently(LarexLangOrderCommand::class,
-                ['from' => config('larex.source_language', 'en'), 'to' => 1]);
+            $this->callSilently(
+                LarexLangOrderCommand::class,
+                ['from' => config('larex.source_language', 'en'), 'to' => 1]
+            );
         }
 
         $this->info('Data imported successfully.');

--- a/src/Exporters/LaravelExporter.php
+++ b/src/Exporters/LaravelExporter.php
@@ -30,8 +30,10 @@ class LaravelExporter implements Exporter
             $command->warn($warning);
         }
 
-        $include = $command->option('include') !== null ? (explode(',', $command->option('include'))) : [];
+        $include = $command->option('include') !== null ? explode(',', $command->option('include')) : [];
         $exclude = $command->option('exclude') !== null ? explode(',', $command->option('exclude')) : [];
+        $normalizeFolderName = $command->option('normalize-folder-name') === 'true';
+
         $eol = config('larex.eol', PHP_EOL);
 
         //finally save the files
@@ -45,7 +47,7 @@ class LaravelExporter implements Exporter
             }
             $found++;
 
-            $folder = str_replace('-', '_', $language);
+            $folder = $normalizeFolderName ? str_replace('-', '_', $language) : $language;
 
             if (!File::exists(lang_path("$folder/"))) {
                 File::makeDirectory(lang_path("$folder/"));
@@ -53,7 +55,11 @@ class LaravelExporter implements Exporter
 
             foreach ($groups as $group => $keys) {
                 $write = fopen(lang_path("$folder/$group.php"), 'wb');
-                fwrite($write, /** @lang text */ "<?php$eol{$eol}return [$eol$eol");
+                fwrite(
+                    $write,
+                    /** @lang text */
+                    "<?php$eol{$eol}return [$eol$eol"
+                );
 
                 foreach ($keys as $key => $value) {
                     self::writeKeyValue($key, $value, $write, 1, $eol);
@@ -78,24 +84,24 @@ class LaravelExporter implements Exporter
         $enclosure = '"';
 
         if (is_array($value)) {
-            fwrite($file, str_repeat('    ', $level)."'$key' => [$eol");
+            fwrite($file, str_repeat('    ', $level) . "'$key' => [$eol");
             $level++;
             foreach ($value as $childKey => $childValue) {
                 self::writeKeyValue($childKey, $childValue, $file, $level, $eol);
             }
-            fwrite($file, str_repeat('    ', $level - 1)."],$eol");
+            fwrite($file, str_repeat('    ', $level - 1) . "],$eol");
 
             return;
         }
 
         $value = (string)$value;
-        $value = str_replace(["'", '\\'.$enclosure], ["\'", $enclosure], $value);
+        $value = str_replace(["'", '\\' . $enclosure], ["\'", $enclosure], $value);
 
         if (is_int($key) || (is_numeric($key) && ctype_digit($key))) {
             $key = (int)$key;
-            fwrite($file, str_repeat('    ', $level)."$key => '$value',$eol");
+            fwrite($file, str_repeat('    ', $level) . "$key => '$value',$eol");
         } else {
-            fwrite($file, str_repeat('    ', $level)."'$key' => '$value',$eol");
+            fwrite($file, str_repeat('    ', $level) . "'$key' => '$value',$eol");
         }
     }
 }

--- a/src/Importers/LaravelImporter.php
+++ b/src/Importers/LaravelImporter.php
@@ -27,6 +27,7 @@ class LaravelImporter implements Importer
     {
         $include = Str::of($command->option('include'))->explode(',')->reject(fn ($i) => empty($i));
         $exclude = Str::of($command->option('exclude'))->explode(',')->reject(fn ($i) => empty($i));
+        $normalizeFolderName = $command->option('normalize-folder-name') === 'true';
 
         /** @var Collection<int,string> $languages */
         $languages = collect([]);
@@ -40,7 +41,7 @@ class LaravelImporter implements Importer
         foreach ($files as $file) {
             $items = include $file;
             $group = pathinfo($file, PATHINFO_FILENAME);
-            $lang = str_replace('_', '-', basename(dirname($file)));
+            $lang = $normalizeFolderName ? str_replace('_', '-', basename(dirname($file))) : basename(dirname($file));
 
             if ($include->isNotEmpty() && !$include->contains($lang)) {
                 continue;

--- a/tests/Exporters/LaravelExporterTest.php
+++ b/tests/Exporters/LaravelExporterTest.php
@@ -97,8 +97,8 @@ it('exports strings with --exclude option', function () {
 
     $this->artisan(LarexExportCommand::class, ['exporter' => 'laravel', '--exclude' => 'en'])
         ->expectsOutput(sprintf("Processing the '%s' file...", csv_path(true)))
-        ->expectsOutput(lang_rpath('it/app.php').' created successfully.')
-        ->expectsOutput(lang_rpath('it/another.php').' created successfully.')
+        ->expectsOutput(lang_rpath('it/app.php') . ' created successfully.')
+        ->expectsOutput(lang_rpath('it/another.php') . ' created successfully.')
         ->assertExitCode(0);
 
     expect(lang_path('en/app.php'))->not->toBeFile();
@@ -219,4 +219,64 @@ it('exports strings trimming whitespaces in group and key', function () {
         ->toBeFile()
         ->fileContent()
         ->toEqualStub('exporters.laravel.spaces.output-it');
+});
+
+it('creates folder with normalize option on', function () {
+    initFromStub('exporters.laravel.normalize.input');
+
+    $this->artisan(LarexExportCommand::class, ['exporter' => 'laravel', '--normalize-folder-name' => 'true'])
+        ->expectsOutput(sprintf("Processing the '%s' file...", csv_path(true)))
+        ->expectsOutput(sprintf('%s created successfully.', lang_rpath('en/app.php')))
+        ->expectsOutput(sprintf('%s created successfully.', lang_rpath('it_100/app.php')))
+        ->assertExitCode(0);
+
+    expect(lang_path('en/app.php'))
+        ->toBeFile()
+        ->fileContent()
+        ->toEqualStub('exporters.laravel.normalize.output-en-app');
+
+    expect(lang_path('it_100/app.php'))
+        ->toBeFile()
+        ->fileContent()
+        ->toEqualStub('exporters.laravel.normalize.output-it-app');
+});
+
+it('creates folder with normalize option on set by user', function () {
+    initFromStub('exporters.laravel.normalize.input');
+
+    $this->artisan(LarexExportCommand::class, ['exporter' => 'laravel'])
+        ->expectsOutput(sprintf("Processing the '%s' file...", csv_path(true)))
+        ->expectsOutput(sprintf('%s created successfully.', lang_rpath('en/app.php')))
+        ->expectsOutput(sprintf('%s created successfully.', lang_rpath('it_100/app.php')))
+        ->assertExitCode(0);
+
+    expect(lang_path('en/app.php'))
+        ->toBeFile()
+        ->fileContent()
+        ->toEqualStub('exporters.laravel.normalize.output-en-app');
+
+    expect(lang_path('it_100/app.php'))
+        ->toBeFile()
+        ->fileContent()
+        ->toEqualStub('exporters.laravel.normalize.output-it-app');
+});
+
+it('creates folder with normalize option off', function () {
+    initFromStub('exporters.laravel.normalize.input');
+
+    $this->artisan(LarexExportCommand::class, ['exporter' => 'laravel', '--normalize-folder-name' => 'false'])
+        ->expectsOutput(sprintf("Processing the '%s' file...", csv_path(true)))
+        ->expectsOutput(sprintf('%s created successfully.', lang_rpath('en/app.php')))
+        ->expectsOutput(sprintf('%s created successfully.', lang_rpath('it-100/app.php')))
+        ->assertExitCode(0);
+
+    expect(lang_path('en/app.php'))
+        ->toBeFile()
+        ->fileContent()
+        ->toEqualStub('exporters.laravel.normalize.output-en-app');
+
+    expect(lang_path('it-100/app.php'))
+        ->toBeFile()
+        ->fileContent()
+        ->toEqualStub('exporters.laravel.normalize.output-it-app');
 });

--- a/tests/Importers/LaravelImporterTest.php
+++ b/tests/Importers/LaravelImporterTest.php
@@ -83,7 +83,8 @@ it('imports strings with territory', function () {
         ->toEqualStub('importers.laravel.territory.output');
 });
 
-it('imports strings and set the source language',
+it(
+    'imports strings and set the source language',
     function (string $source, string $expected, bool $skipSourceReordering) {
         File::makeDirectory(lang_path('ar'), 0755, true, true);
         File::makeDirectory(lang_path('en'), 0755, true, true);
@@ -95,8 +96,10 @@ it('imports strings and set the source language',
 
         config(['larex.source_language' => $source]);
 
-        $this->artisan(LarexImportCommand::class,
-            ['importer' => 'laravel', '--skip-source-reordering' => $skipSourceReordering])
+        $this->artisan(
+            LarexImportCommand::class,
+            ['importer' => 'laravel', '--skip-source-reordering' => $skipSourceReordering]
+        )
             ->expectsOutput('Importing entries...')
             ->expectsOutput('Data imported successfully.')
             ->assertExitCode(0);
@@ -105,9 +108,64 @@ it('imports strings and set the source language',
             ->toBeFile()
             ->fileContent()
             ->toEqualStub($expected);
-    })->with([
-        'ar' => ['ar', 'importers.laravel.source.output-ar', false],
-        'en' => ['en', 'importers.laravel.source.output-en', false],
-        'en-skip' => ['en', 'importers.laravel.source.output-ar', true],
-        'invalid-lang' => ['es', 'importers.laravel.source.output-ar', false],
-    ]);
+    }
+)->with([
+    'ar' => ['ar', 'importers.laravel.source.output-ar', false],
+    'en' => ['en', 'importers.laravel.source.output-en', false],
+    'en-skip' => ['en', 'importers.laravel.source.output-ar', true],
+    'invalid-lang' => ['es', 'importers.laravel.source.output-ar', false],
+]);
+
+it('imports strings with normalize option on', function () {
+    File::makeDirectory(lang_path('en'), 0755, true, true);
+    File::makeDirectory(lang_path('it'), 0755, true, true);
+
+    initFromStub('importers.laravel.normalize.input-en-simple', lang_path('en/simple.php'));
+    initFromStub('importers.laravel.normalize.input-it-simple', lang_path('it_100/simple.php'));
+
+    $this->artisan(LarexImportCommand::class, ['importer' => 'laravel'])
+        ->expectsOutput('Importing entries...')
+        ->expectsOutput('Data imported successfully.')
+        ->assertExitCode(0);
+
+    expect(csv_path())
+        ->toBeFile()
+        ->fileContent()
+        ->toEqualStub('importers.laravel.normalize.output_normalized');
+});
+
+it('imports strings with normalize option on set by user', function () {
+    File::makeDirectory(lang_path('en'), 0755, true, true);
+    File::makeDirectory(lang_path('it'), 0755, true, true);
+
+    initFromStub('importers.laravel.normalize.input-en-simple', lang_path('en/simple.php'));
+    initFromStub('importers.laravel.normalize.input-it-simple', lang_path('it_100/simple.php'));
+
+    $this->artisan(LarexImportCommand::class, ['importer' => 'laravel', '--normalize-folder-name' => 'true'])
+        ->expectsOutput('Importing entries...')
+        ->expectsOutput('Data imported successfully.')
+        ->assertExitCode(0);
+
+    expect(csv_path())
+        ->toBeFile()
+        ->fileContent()
+        ->toEqualStub('importers.laravel.normalize.output_normalized');
+});
+
+it('imports strings with normalize option off', function () {
+    File::makeDirectory(lang_path('en'), 0755, true, true);
+    File::makeDirectory(lang_path('it'), 0755, true, true);
+
+    initFromStub('importers.laravel.normalize.input-en-simple', lang_path('en/simple.php'));
+    initFromStub('importers.laravel.normalize.input-it-simple', lang_path('it_100/simple.php'));
+
+    $this->artisan(LarexImportCommand::class, ['importer' => 'laravel', '--normalize-folder-name' => 'false'])
+        ->expectsOutput('Importing entries...')
+        ->expectsOutput('Data imported successfully.')
+        ->assertExitCode(0);
+
+    expect(csv_path())
+        ->toBeFile()
+        ->fileContent()
+        ->toEqualStub('importers.laravel.normalize.output_normalized_false');
+});

--- a/tests/Stubs/exporters/laravel/normalize/input.stub
+++ b/tests/Stubs/exporters/laravel/normalize/input.stub
@@ -1,0 +1,14 @@
+group,key,en,it-100
+app,first,First,Primo
+app,second,Second,Secondo
+app,third,Third,Terzo
+special,multi.a,A,a
+special,multi.b,B,b
+special,empty.escape,nope,""
+special,empty.noescape,nope,
+special,enclosure,nope,"è ""molto"" bello"
+special,numeric.1,January,Gennaio
+special,numeric.2,February,Febbraio
+special,numeric.3,March,Marzo
+special,space.escape,nope," "
+special,space.noescape,nope, 

--- a/tests/Stubs/exporters/laravel/normalize/output-en-app.stub
+++ b/tests/Stubs/exporters/laravel/normalize/output-en-app.stub
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'first' => 'First',
+    'second' => 'Second',
+    'third' => 'Third',
+
+];

--- a/tests/Stubs/exporters/laravel/normalize/output-it-app.stub
+++ b/tests/Stubs/exporters/laravel/normalize/output-it-app.stub
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'first' => 'Primo',
+    'second' => 'Secondo',
+    'third' => 'Terzo',
+
+];

--- a/tests/Stubs/importers/laravel/normalize/input-en-simple.stub
+++ b/tests/Stubs/importers/laravel/normalize/input-en-simple.stub
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'hello' => 'Hello',
+
+];

--- a/tests/Stubs/importers/laravel/normalize/input-it-simple.stub
+++ b/tests/Stubs/importers/laravel/normalize/input-it-simple.stub
@@ -1,0 +1,8 @@
+<?php
+
+return [
+
+    'hello' => 'Ciao',
+    'bike'  => 'Bicicletta'
+
+];

--- a/tests/Stubs/importers/laravel/normalize/output_normalized.stub
+++ b/tests/Stubs/importers/laravel/normalize/output_normalized.stub
@@ -1,0 +1,3 @@
+group,key,en,it-100
+simple,hello,Hello,Ciao
+simple,bike,,Bicicletta

--- a/tests/Stubs/importers/laravel/normalize/output_normalized_false.stub
+++ b/tests/Stubs/importers/laravel/normalize/output_normalized_false.stub
@@ -1,0 +1,3 @@
+group,key,en,it_100
+simple,hello,Hello,Ciao
+simple,bike,,Bicicletta


### PR DESCRIPTION
We are currently using or abusing the localization feature in Laravel to allow for custom user specific labeling of certain parts of the codebase. This is currently implemented by having the folder names with `-` in them, which the current flow does automatically normalize into `_`.

This PR should make it available to add an optional flag to disable the current behavior if needed while keeping backwards compatibility.

Hopefully this is useful :) let me know if this should be extended to the other exporters also.